### PR TITLE
add WHconLru : LRU cache for WHconsed, too

### DIFF
--- a/benches/traversals.rs
+++ b/benches/traversals.rs
@@ -39,10 +39,10 @@ struct ActualTerm {
 
 impl fmt::Display for ActualTerm {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match &self.op {
-            &Op::Var(i) => write!(fmt, "v{}", i),
-            &Op::Lam => write!(fmt, "({})", self.children[0]),
-            &Op::App => write!(fmt, "{}.{}", self.children[0], self.children[1]),
+        match self.op {
+            Op::Var(i) => write!(fmt, "v{}", i),
+            Op::Lam => write!(fmt, "({})", self.children[0]),
+            Op::App => write!(fmt, "{}.{}", self.children[0], self.children[1]),
         }
     }
 }
@@ -148,7 +148,7 @@ impl std::iter::Iterator for PostOrderIter {
     type Item = Term;
     fn next(&mut self) -> Option<Term> {
         while let Some((children_pushed, t)) = self.stack.last() {
-            if self.visited.contains(&t) {
+            if self.visited.contains(t) {
                 self.stack.pop();
             } else if !children_pushed {
                 self.stack.last_mut().unwrap().0 = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,15 @@ impl<T> Hash for WHConsed<T> {
     }
 }
 
+impl<T> Clone for WHConsed<T> {
+    fn clone(&self) -> Self {
+        WHConsed {
+            elm: self.elm.clone(),
+            uid: self.uid,
+        }
+    }
+}
+
 impl<T> PartialEq for WHConsed<T> {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -15,10 +15,10 @@ enum ActualTerm {
 
 impl fmt::Display for ActualTerm {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &Self::Var(i) => write!(fmt, "v{}", i),
-            &Self::Lam(ref t) => write!(fmt, "({})", t.get()),
-            &Self::App(ref u, ref v) => write!(fmt, "{}.{}", u.get(), v.get()),
+        match *self {
+            Self::Var(i) => write!(fmt, "v{}", i),
+            Self::Lam(ref t) => write!(fmt, "({})", t.get()),
+            Self::App(ref u, ref v) => write!(fmt, "{}.{}", u.get(), v.get()),
         }
     }
 }
@@ -87,7 +87,7 @@ fn run() {
     let is_new = set.insert(v3.clone());
     assert!(!is_new);
 
-    let (lam2, lam2_name) = (consign.lam(v3.clone()), "lam2");
+    let (lam2, lam2_name) = (consign.lam(v3), "lam2");
     println!("creating {}", lam2);
     assert_eq!(consign.len(), 3);
     assert_eq!(lam.uid(), lam2.uid());
@@ -101,7 +101,7 @@ fn run() {
     assert_eq!(consign.len(), 4);
     let prev = map.insert(app.clone(), app_name);
     assert_eq!(prev, None);
-    let is_new = set.insert(app.clone());
+    let is_new = set.insert(app);
     assert!(is_new);
 
     for term in &set {

--- a/src/test/collect.rs
+++ b/src/test/collect.rs
@@ -46,15 +46,13 @@ pub fn create_1() -> Term {
     let var = term::var("v_2");
     let cst = term::cst(8);
     let app_1 = term::app("+", vec![var, cst]);
-    let app_2 = term::app("-", vec![app_1]);
-    app_2
+    term::app("-", vec![app_1])
 }
 pub fn create_2() -> Term {
     let var = term::var("v_1");
     let cst = term::cst(7);
     let app_1 = term::app("+", vec![var, cst]);
-    let app_2 = term::app("-", vec![app_1]);
-    app_2
+    term::app("-", vec![app_1])
 }
 
 pub fn factory_len() -> usize {

--- a/tests/try_build/issue_1.stderr
+++ b/tests/try_build/issue_1.stderr
@@ -1,5 +1,5 @@
 warning: unused import: `HConsed`
- --> tests/try_build/issue_1.rs:5:19
+ --> $DIR/issue_1.rs:5:19
   |
 5 | use hashconsing::{HConsed, HConsign, HashConsign};
   |                   ^^^^^^^
@@ -7,14 +7,14 @@ warning: unused import: `HConsed`
   = note: `#[warn(unused_imports)]` on by default
 
 error[E0277]: `Cell<RefOrInt<'_>>` cannot be shared between threads safely
-   --> tests/try_build/issue_1.rs:37:11
+   --> $DIR/issue_1.rs:37:11
     |
 37  |         s.spawn(move |_| {
     |           ^^^^^ `Cell<RefOrInt<'_>>` cannot be shared between threads safely
     |
     = help: within `&HashableCell<RefOrInt<'_>>`, the trait `Sync` is not implemented for `Cell<RefOrInt<'_>>`
 note: required because it appears within the type `HashableCell<RefOrInt<'_>>`
-   --> tests/try_build/issue_1.rs:18:8
+   --> $DIR/issue_1.rs:18:8
     |
 18  | struct HashableCell<T: Eq + PartialEq + Copy> {
     |        ^^^^^^^^^^^^
@@ -23,7 +23,7 @@ note: required because it appears within the type `HashableCell<RefOrInt<'_>>`
     = note: required because it appears within the type `HConsed<&HashableCell<RefOrInt<'_>>>`
     = note: required because it appears within the type `[closure@$DIR/tests/try_build/issue_1.rs:37:17: 45:10]`
 note: required by a bound in `crossbeam_utils::thread::Scope::<'env>::spawn`
-   --> $CARGO/crossbeam-utils-0.8.6/src/thread.rs
+   --> $DIR/thread.rs:248:12
     |
-    |         F: Send + 'env,
+248 |         F: Send + 'env,
     |            ^^^^ required by this bound in `crossbeam_utils::thread::Scope::<'env>::spawn`

--- a/tests/try_build/issue_1.stderr
+++ b/tests/try_build/issue_1.stderr
@@ -1,5 +1,5 @@
 warning: unused import: `HConsed`
- --> $DIR/issue_1.rs:5:19
+ --> tests/try_build/issue_1.rs:5:19
   |
 5 | use hashconsing::{HConsed, HConsign, HashConsign};
   |                   ^^^^^^^
@@ -7,14 +7,14 @@ warning: unused import: `HConsed`
   = note: `#[warn(unused_imports)]` on by default
 
 error[E0277]: `Cell<RefOrInt<'_>>` cannot be shared between threads safely
-   --> $DIR/issue_1.rs:37:11
+   --> tests/try_build/issue_1.rs:37:11
     |
 37  |         s.spawn(move |_| {
     |           ^^^^^ `Cell<RefOrInt<'_>>` cannot be shared between threads safely
     |
     = help: within `&HashableCell<RefOrInt<'_>>`, the trait `Sync` is not implemented for `Cell<RefOrInt<'_>>`
 note: required because it appears within the type `HashableCell<RefOrInt<'_>>`
-   --> $DIR/issue_1.rs:18:8
+   --> tests/try_build/issue_1.rs:18:8
     |
 18  | struct HashableCell<T: Eq + PartialEq + Copy> {
     |        ^^^^^^^^^^^^
@@ -22,8 +22,8 @@ note: required because it appears within the type `HashableCell<RefOrInt<'_>>`
     = note: required because of the requirements on the impl of `Send` for `Arc<&HashableCell<RefOrInt<'_>>>`
     = note: required because it appears within the type `HConsed<&HashableCell<RefOrInt<'_>>>`
     = note: required because it appears within the type `[closure@$DIR/tests/try_build/issue_1.rs:37:17: 45:10]`
-note: required by a bound in `Scope::<'env>::spawn`
-   --> $DIR/thread.rs:248:12
+note: required by a bound in `crossbeam_utils::thread::Scope::<'env>::spawn`
+   --> $CARGO/crossbeam-utils-0.8.6/src/thread.rs
     |
-248 |         F: Send + 'env,
-    |            ^^^^ required by this bound in `Scope::<'env>::spawn`
+    |         F: Send + 'env,
+    |            ^^^^ required by this bound in `crossbeam_utils::thread::Scope::<'env>::spawn`


### PR DESCRIPTION
This is an LRU cache variant for WHConsed<T>. (I'm using this in the continued quest to reduce memory consumption. In this case, I don't want the constant-folding cache to cause us to retain references to otherwise dead terms.)

It also adds Clone impl for WHConsed<T>. (BTW: why are the Clone impls manual instead of derived? They appear to be exactly what would be derived. Should we fix this?)

It also fixes the tests.